### PR TITLE
Add multiple style tag to support client components

### DIFF
--- a/src/AntdRegistry.tsx
+++ b/src/AntdRegistry.tsx
@@ -9,15 +9,15 @@ type AntdRegistryProps = Omit<StyleProviderProps, 'cache'>;
 
 const AntdRegistry: FC<AntdRegistryProps> = (props) => {
   const [cache] = useState(() => createCache());
-  const inserted = useRef(false);
+  const inserted = useRef('');
 
   useServerInsertedHTML(() => {
     const styleText = extractStyle(cache, { plain: true });
 
-    if (inserted.current) {
+    if (inserted.current === styleText) {
       return null;
     }
-    inserted.current = true;
+    inserted.current = styleText;
 
     return (
       <style


### PR DESCRIPTION
We will have a case page.tsx is server or client components

This pull can fix these issues (page.tsx is a server component)
https://github.com/ant-design/ant-design/issues/47122
https://github.com/ant-design/ant-design/issues/47104

In this case, the first time only remaining some components, not enough
the second time also only remaining some components, not enough
That's why we need both.